### PR TITLE
Bug Fixes and Improvements

### DIFF
--- a/nRF8001.h
+++ b/nRF8001.h
@@ -5,6 +5,7 @@
 
 #ifndef NRF_DEBUG
 #define NRF_DEBUG 1
+//#define NRF_VERBOSE_DEBUG 1
 #endif
 
 typedef uint8_t nRFLen;


### PR DESCRIPTION
- changed all strings to use F() macro to conserve RAM
- moved some messages to new NRF_VERBOSE_DEBUG conditional to make debugging with NRF_DEBUG on more viable
- added display of details of any hardware error event inside debugEvent()
- fix a bug in handling 64 bit pipesOpen and pipesClosed members -- don't return AND masked pipesOpen value as an 8 bit integer or you can only use 8 pipes -- instead, compare result of the mask to 0, and return the boolean result
- be more deliberate in handling the 64 bit pipesOpen and pipesClosed masking to ensure compiler uses a 64 bit mask
- implement getDeviceVersion()
