### PR TITLE
Don't spend a credit when setLocalData is called.

### DIFF
--- a/nRF8001.cpp
+++ b/nRF8001.cpp
@@ -641,7 +641,7 @@ nRFTxStatus nRF8001::transmitReceive(nRFCommand *txCmd, uint16_t timeout)
     if (txLength &&
        (txCmd->command == NRF_SENDDATA_OP
      || txCmd->command == NRF_REQUESTDATA_OP
-     || txCmd->command == NRF_SETLOCALDATA_OP
+     //|| txCmd->command == NRF_SETLOCALDATA_OP
      || txCmd->command == NRF_SENDDATAACK_OP
      || txCmd->command == NRF_SENDDATANACK_OP)) {
         if (credits < 1) {


### PR DESCRIPTION
See https://devzone.nordicsemi.com/question/3678/nrf8001-data-credit-system-details/?answer=3702#post-id-3702 for more details. There may be a case where this is not right when advertising, but as far as we can tell this change is needed.
