### PR TITLE
Add PlatformIO Library Registry manifest file

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,12 @@
+{
+  "name": "NRF8001",
+  "keywords": "spi, bluetooth, driver",
+  "description": "Arduino library for the Nordic nRF8001 Bluetooth Low Energy chip",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com//guanix/arduino-nrf8001.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com//guanix/arduino-nrf8001.git"
+    "url": "https://github.com/guanix/arduino-nrf8001.git"
   },
   "frameworks": "arduino",
   "platforms": "atmelavr"


### PR DESCRIPTION
- Add library.json file. This allows the libraries to be managed from within 
  PlatformIO (see http://platformio.org/)
